### PR TITLE
PerformanceEstimatorPlugin.cpp: comment out destructor to avoid segfault as sim exit

### DIFF
--- a/src/PerformanceEstimatorPlugin.cpp
+++ b/src/PerformanceEstimatorPlugin.cpp
@@ -104,11 +104,10 @@ PerformanceEstimatorPlugin::PerformanceEstimatorPlugin(etiss::Configuration* con
   
 }
 
-PerformanceEstimatorPlugin::~PerformanceEstimatorPlugin()
-{
-  delete channel_ptr;
-  delete estimator_ptr;
-  delete tracePrinter_ptr;
+PerformanceEstimatorPlugin::~PerformanceEstimatorPlugin() {
+  // delete channel_ptr;
+  // delete estimator_ptr;
+  // delete tracePrinter_ptr;
 }
 
 std::string PerformanceEstimatorPlugin::_getPluginName() const


### PR DESCRIPTION
The following segfault at the end of the simulation (leading to a non-zero exit code) seems to be caused by the destructor.

```
CPU0 exited with exception: 0x80000000: Finished cpu execution. This is the proper way to exit from etiss::CPUCore::execute.
[1]    3523153 segmentation fault (core dumped)  ./build_dir/installed/bin/bare_etiss_processor
```

This is more like a workaround for the actual problem, but ignoring the exit code of etiss is also not acceptable...

@danielschloms 