### PR TITLE
Expose performance estimator cycle count to etiss at runtime

### DIFF
--- a/include/SoftwareEval/PerformanceEstimatorPlugin.h
+++ b/include/SoftwareEval/PerformanceEstimatorPlugin.h
@@ -38,6 +38,7 @@ public:
 
   virtual std::string _getPluginName() const;
   virtual void *getPluginHandle();
+  virtual etiss::int64 getEstimatedCycleCount() override;
 
 private:  
 

--- a/include/SoftwareEval/TracePrinterPlugin.h
+++ b/include/SoftwareEval/TracePrinterPlugin.h
@@ -39,6 +39,7 @@ public:
 
   virtual std::string _getPluginName() const;
   virtual void *getPluginHandle();
+  virtual etiss::int64 getEstimatedCycleCount() override;
 
 private:  
 

--- a/src/PerformanceEstimatorPlugin.cpp
+++ b/src/PerformanceEstimatorPlugin.cpp
@@ -140,3 +140,8 @@ void PerformanceEstimatorPlugin::finalizeTrace(void)
     tracePrinter_ptr->finalize();
   }
 }
+
+etiss::int64 PerformanceEstimatorPlugin::getEstimatedCycleCount(void)
+{
+    return estimator_ptr->getEstimatedCycleCount();
+}

--- a/src/TracePrinterPlugin.cpp
+++ b/src/TracePrinterPlugin.cpp
@@ -145,3 +145,8 @@ void TracePrinterPlugin::finalizeTrace(void)
   tracePrinter_ptr->execute();
   tracePrinter_ptr->finalize();
 }
+
+etiss::int64 TracePrinterPlugin::getEstimatedCycleCount(void)
+{
+    return 0;
+}

--- a/src/TracerPlugin.cpp
+++ b/src/TracerPlugin.cpp
@@ -34,12 +34,12 @@ namespace TracerPlugin
 {
 
 TracerPlugin::TracerPlugin()
-{} 
+{}
 
 TracerPlugin::~TracerPlugin() {} // TODO: Remove?
 
 void TracerPlugin::initCodeBlock(CodeBlock & block) const
-{ 
+{
   for(auto monitor_i = monitor_set.begin(); monitor_i != monitor_set.end(); monitor_i++)
   {
     block.fileglobalCode().insert((*monitor_i)->getBlockDeclarations());
@@ -71,7 +71,7 @@ void TracerPlugin::finalizeInstrSet(instr::ModedInstructionSet &mis) const
 
           cs.append(CodePart::PREINITIALDEBUGRETURNING).code() = preCode_strs.str();
 	  cs.append(CodePart::INITIALREQUIRED).code() = postCode_strs.str();
-	  	    
+
 	  return true;
 	},0);
       });
@@ -81,7 +81,7 @@ void TracerPlugin::finalizeInstrSet(instr::ModedInstructionSet &mis) const
 }
 
 int32 TracerPlugin::execute(void)
-{  
+{
   processTrace();
 
 
@@ -90,7 +90,7 @@ int32 TracerPlugin::execute(void)
   {
     (*monitor_i)->resetCounter();
   }
-  
+
   return 0;
 }
 
@@ -103,7 +103,7 @@ void TracerPlugin::executionEnd(int32_t code)
     (*monitor_i)->resetCounter();
   }
 }
-  
+
 std::string TracerPlugin::_getPluginName() const
 {
   return "TracerPlugin";


### PR DESCRIPTION
This is required to access the current cycle count estimation using ETISS/RISC-V MCYCLE CSRs

Related PRs:
- SoftwareEval-Backends: https://github.com/tum-ei-eda/SoftwareEval-Backends/pull/4
- ETISS: Will be created after other are merged